### PR TITLE
fields/timestamp: fix Timestmap.Truncate issues

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -56,7 +56,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.45
+          version: v1.46
           github-token: ${{ secrets.GITHUB_TOKEN }}
           only-new-issues: false
           skip-cache: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,8 +5,6 @@ linters:
     - gci # Control golang package import order and make it always deterministic.
     - godot # Check if comments end in a period.
     - misspell # Finds commonly misspelled English words in comments.
-    - rowserrcheck # Checks whether Err of rows is checked successfully.
-    - sqlclosecheck # Checks that sql.Rows and sql.Stmt are closed.
     - goheader # Checks is file header matches pattern.
 
 linters-settings:
@@ -15,5 +13,5 @@ linters-settings:
       const:
         COMPANY: Searis AS
       regexp:
-        ANY_AUTHOR: (, .*)*
+        ANY_AUTHOR: "(.*)"
     template-path: .go-header.tmpl

--- a/example_test.go
+++ b/example_test.go
@@ -75,7 +75,6 @@ func ExampleClient_SelectSignals() {
 }
 
 func ExampleClient_DataFrame() {
-	const inputID = "temp"
 	const integrationID = "c8ktonqsahsmemfs7lv0"
 	const itemID = "c8l95d2sahsh22imiabg"
 

--- a/fields/duration_test.go
+++ b/fields/duration_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestParseFixedDuration(t *testing.T) {
-	tcs := []struct {
+	testCases := []struct {
 		s   string
 		d   time.Duration
 		err error
@@ -42,7 +42,7 @@ func TestParseFixedDuration(t *testing.T) {
 		{s: "P1W", d: time.Hour * 24 * 7},
 	}
 
-	for _, tc := range tcs {
+	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.s, func(t *testing.T) {
 			d, err := fields.ParseFixedDuration(tc.s)

--- a/fields/timestamp.go
+++ b/fields/timestamp.go
@@ -38,10 +38,15 @@ const (
 // OriginTime). Note that this is not fully equivalent to using Truncate on the
 // time.Time type, as we are deliberately using a different origin.
 func (ts Timestamp) Truncate(d time.Duration) Timestamp {
-	if d == 0 {
+	if d <= 0 {
 		return ts
 	}
-	r := (ts - OriginTime) % Timestamp(d)
+	td := Timestamp(d) / 1e3
+
+	r := (ts - OriginTime) % td
+	if r < 0 {
+		r += td
+	}
 	return ts - r
 }
 

--- a/fields/timestamp_test.go
+++ b/fields/timestamp_test.go
@@ -15,28 +15,155 @@
 package fields_test
 
 import (
+	"fmt"
+	"math"
 	"testing"
 	"time"
 
-	data "github.com/clarify/clarify-go/fields"
+	"github.com/clarify/clarify-go/fields"
 )
 
 func TestOriginTime(t *testing.T) {
 	expectTime := time.Date(2000, 01, 03, 0, 0, 0, 0, time.UTC)
-	if result := data.OriginTime.Time(); !result.Equal(expectTime) {
+	if result := fields.OriginTime.Time(); !result.Equal(expectTime) {
 		t.Errorf("expected OriginZeroTime.Time() equal %v, got %v", expectTime, result)
 	}
-	if result := int64(data.OriginTime); result != expectTime.UnixMicro() {
+	if result := int64(fields.OriginTime); result != expectTime.UnixMicro() {
 		t.Errorf("expected OriginZeroTime equal %v, got %v", expectTime.UnixMicro(), result)
 	}
 }
 
 func TestZeroTime(t *testing.T) {
 	expectTime := time.Date(1970, 01, 01, 0, 0, 0, 0, time.UTC)
-	if result := data.Timestamp(0).Time(); !result.Equal(expectTime) {
+	if result := fields.Timestamp(0).Time(); !result.Equal(expectTime) {
 		t.Errorf("expected Timestamp(0).Time() equal %v, got %v", expectTime, result)
 	}
-	if result := int64(data.Timestamp(0)); result != expectTime.UnixMicro() {
+	if result := int64(fields.Timestamp(0)); result != expectTime.UnixMicro() {
 		t.Errorf("expected Timestamp(0) equal %v, got %v", expectTime.UnixMicro(), result)
+	}
+}
+
+func TestTimestampTruncate(t *testing.T) {
+	// test1 is valid only when the different origin between Timestamp and
+	// Time is insignificant.
+
+	test := func(ts fields.Timestamp, d time.Duration) func(t *testing.T) {
+		return func(t *testing.T) {
+			t.Helper()
+
+			// Compare result against multiple alternate implementations; the
+			// first case is allowed to fail.
+			t.Run("ts.Truncate(d).Time()==ts.Time().Truncate(d)", softCompareTimestampTruncateTime(ts, d))
+			t.Run("ts.Truncate(d)==timestampTimeBucket(ts,d,origin,min,max)", compareTimestampTruncateTimescale(ts, d))
+			t.Run("ts.Truncate(d)==custom", compareTimestampTruncateCustom(ts, d))
+		}
+	}
+
+	// Many cases are found/adapted from FuzzTimestampTruncate.
+	now := time.Now().UTC()
+	t.Run("now.Truncate(24h)", test(fields.AsTimestamp(now), 24*time.Hour))
+	t.Run("now.Truncate(7*24h)", test(fields.AsTimestamp(now), 7*24*time.Hour))
+	t.Run("now.Truncate(1h)", test(fields.AsTimestamp(now), time.Hour))
+	t.Run("now.Truncate(-1h)", test(fields.AsTimestamp(now), -time.Hour))
+	t.Run("now.Truncate(1min)", test(fields.AsTimestamp(now), time.Minute))
+	t.Run("now.Truncate(-1min)", test(fields.AsTimestamp(now), -time.Minute))
+	t.Run("now.Truncate(1µs)", test(fields.AsTimestamp(now), time.Microsecond))
+	t.Run("now.Truncate(3µs)", test(fields.AsTimestamp(now), time.Microsecond))
+	t.Run("now.Truncate(-1µs)", test(fields.AsTimestamp(now), -time.Microsecond))
+	t.Run("now.Truncate(35µs)", test(fields.AsTimestamp(now), 35*time.Microsecond))
+	t.Run("now.Truncate(-35µs)", test(fields.AsTimestamp(now), -35*time.Microsecond))
+	t.Run("Timestamp(1).Truncate(1µs)", test(fields.Timestamp(1), 1*time.Microsecond))
+	t.Run("Timestamp(origin-1h30min).Truncate(1h)", test(fields.OriginTime.Add(-1*time.Hour-30*time.Minute), time.Hour))
+	t.Run("Timestamp(origin-1).Truncate(2µs)", test(fields.OriginTime-1, 2*time.Microsecond))
+	t.Run("Timestamp(origin-1).Truncate(3µs)", test(fields.OriginTime-1, 3*time.Microsecond))
+	t.Run("Timestamp(origin+1).Truncate(2µs)", test(fields.OriginTime+1, 2*time.Microsecond))
+	t.Run("Timestamp(origin+1).Truncate(3µs)", test(fields.OriginTime+1, 3*time.Microsecond))
+	t.Run("Timestamp(-1).Truncate(2µs)", test(-1, 2*time.Microsecond))
+	t.Run("Timestamp(1).Truncate(2µs)", test(1, 2*time.Microsecond))
+	t.Run("Timestamp(1).Truncate(3µs)", test(1, 3*time.Microsecond))
+	t.Run("Timestamp(3).Truncate(3µs)", test(3, 3*time.Microsecond))
+	t.Run("Timestamp(-3).Truncate(3µs)", test(3, 3*time.Microsecond))
+	t.Run("Timestamp(-1).Truncate(3µs)", test(-1, 3*time.Microsecond))
+	t.Run("Timestamp(1).Truncate(11µs)", test(1, 11*time.Microsecond))
+	t.Run("Timestamp(1).Truncate(13s)", test(1, 13*time.Microsecond))
+
+}
+
+func FuzzTimestampTruncate(f *testing.F) {
+	//origTime := time.Date(2000, 01, 03, 0, 0, 0, 0, time.UTC)
+	f.Fuzz(func(t *testing.T, msec, dMsec int64) {
+		ts := fields.Timestamp(msec)
+		d := time.Duration(dMsec) * time.Microsecond
+
+		testName := fmt.Sprintf("Timestamp(%v).Truncate(%v)",
+			ts.Time().Format(time.RFC3339Nano+" (Mon)"),
+			d,
+		)
+
+		// Compare result against multiple alternate implementations; the
+		// first case is allowed to fail.
+		t.Run(testName+".Time()==ts.Time().Truncate(d)", softCompareTimestampTruncateTime(ts, d))
+		t.Run(testName+"==timestampTimeBucket(ts,d,origin,min,max)", compareTimestampTruncateTimescale(ts, d))
+		t.Run(testName+"==custom", compareTimestampTruncateCustom(ts, d))
+	})
+
+}
+
+func softCompareTimestampTruncateTime(ts fields.Timestamp, d time.Duration) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Helper()
+
+		expect := ts.Time().Truncate(d)
+		result := ts.Truncate(d).Time()
+		if !expect.Equal(result) {
+			// This test is not expected tp pass for all cases; only log the
+			// error.
+			t.Logf("Test does not pass:\nGot:  %v\nWant: %v", result, expect)
+		}
+	}
+}
+
+func compareTimestampTruncateTimescale(ts fields.Timestamp, d time.Duration) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Helper()
+
+		var expect int64
+		if d > 0 {
+			expect = timescaleTimeBucket(d.Microseconds(), int64(ts), int64(fields.OriginTime), math.MinInt64, math.MaxInt64)
+		} else {
+			expect = int64(ts)
+		}
+
+		result := int64(ts.Truncate(d))
+		if expect != result {
+			t.Errorf("Unexpected result:\nGot:  %v\nWant: %v", result, expect)
+		}
+	}
+}
+
+func compareTimestampTruncateCustom(ts fields.Timestamp, d time.Duration) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Helper()
+
+		td := fields.Timestamp(d.Microseconds())
+		result := ts.Truncate(d)
+
+		var expect fields.Timestamp
+		if td > 0 {
+			tsRelOrigin := ts - fields.OriginTime
+			m := tsRelOrigin / td
+			if tsRelOrigin < 0 && (tsRelOrigin)%td != 0 {
+				m--
+			}
+			expect = fields.OriginTime + td*m
+		} else {
+			expect = ts
+		}
+
+		if expect != result {
+			t.Errorf("Unexpected result:\nGot:  %v\nWant: %v",
+				result, expect,
+			)
+		}
 	}
 }

--- a/fields/timestamp_timescale_test.go
+++ b/fields/timestamp_timescale_test.go
@@ -1,0 +1,46 @@
+// Copyright 2022 Searis AS, 2017-2022 Timescale, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fields_test
+
+// timestampTimeBucket is a direct Go translation of C code from Timescale. We
+// use it as a reference check for our own implementation.
+// https://github.com/timescale/timescaledb/blob/a6b5f9002cf4f3894aa8cbced7f862a73784cada/src/time_bucket.c#L18
+func timescaleTimeBucket(period, timestamp, offset, min, max int64) int64 {
+	if period <= 0 {
+		panic("period must be greater than 0")
+	}
+	if offset != 0 {
+		// We need to ensure that the timestamp is in range _after_ the
+		// offset is applied: when the offset is positive we need to make
+		// sure the resultant time is at least min, and when negative that
+		// it is less than the max.
+		offset = offset % period
+		if (offset > 0 && timestamp < min+offset) || (offset < 0 && timestamp > max+offset) {
+			panic("timestamp out of range")
+		}
+		timestamp -= offset
+	}
+
+	result := (timestamp / period) * period
+	if timestamp < 0 && timestamp%period != 0 {
+		if result < (min)+(period) {
+			panic("timestamp out of range")
+		}
+		result -= period
+	}
+	result += offset
+
+	return result
+}

--- a/jsonrpc/resource/request_plain.go
+++ b/jsonrpc/resource/request_plain.go
@@ -43,7 +43,6 @@ type Request[R any] struct {
 	method     string
 
 	baseParams []jsonrpc.Param
-	createOnly bool
 
 	h jsonrpc.Handler
 }


### PR DESCRIPTION
commit bf5216a99cdcaaa664fc6f8c849ca59b4ff8200b (HEAD -> fixes, origin/fixes)
Author: Sindre Myren <sindre@clarify.io>
Date:   Fri Jun 24 01:51:59 2022 +0200

    lint: update config, remove dead code

commit 819574f05d099567a065c5d4cf8f22c6f2ddf7b5
Author: Sindre Myren <sindre@clarify.io>
Date:   Wed Jun 22 15:17:27 2022 +0200

    fields/timestamp: fix Timestmap.Truncate issues

    Fix issues with the Timestmap.Truncate method, and add relevant tests,
    including Fuzz tests. The main issue was that it was missing a division
    by 1e3 to get the value in the same resolution as the Timestamp type.

    Secondly, there where semantical issues at and around the origin time,
    as well as at and around the UNIX zero time. The cases where found via
    Fuzzing, and added to the normal tests afterwards.
