### PR TITLE
jsonrpc/resources: move MetaSave to views (breaking)

### DIFF
--- a/examples/save_signals/main.go
+++ b/examples/save_signals/main.go
@@ -7,7 +7,6 @@ import (
 
 	clarify "github.com/clarify/clarify-go"
 	"github.com/clarify/clarify-go/fields"
-	"github.com/clarify/clarify-go/jsonrpc/resource"
 	"github.com/clarify/clarify-go/views"
 )
 
@@ -32,7 +31,7 @@ func main() {
 
 	inputs := map[string]views.SignalSave{
 		"a": {
-			MetaSave: resource.MetaSave{
+			MetaSave: views.MetaSave{
 				Annotations: annotations,
 			},
 			SignalSaveAttributes: views.SignalSaveAttributes{
@@ -44,7 +43,7 @@ func main() {
 			},
 		},
 		"b": {
-			MetaSave: resource.MetaSave{
+			MetaSave: views.MetaSave{
 				Annotations: annotations,
 			},
 			SignalSaveAttributes: views.SignalSaveAttributes{

--- a/jsonrpc/resource/resource.go
+++ b/jsonrpc/resource/resource.go
@@ -128,8 +128,3 @@ type Meta struct {
 	CreatedAt         time.Time          `json:"createdAt"`
 	UpdatedAt         time.Time          `json:"updatedAt"`
 }
-
-// MetaSave holds the mutable meta data fields for a resource entry.
-type MetaSave struct {
-	Annotations fields.Annotations `json:"annotations,omitempty"`
-}

--- a/views/item.go
+++ b/views/item.go
@@ -27,7 +27,7 @@ type ItemInclude struct{}
 // ItemSave describe the save view for an item.
 type ItemSave struct {
 	ItemSaveAttributes
-	resource.MetaSave
+	MetaSave
 }
 
 // PublishedItem constructs a view for an item based on the passed in signal,

--- a/views/resource.go
+++ b/views/resource.go
@@ -1,0 +1,22 @@
+// Copyright 2022 Searis AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package views
+
+import "github.com/clarify/clarify-go/fields"
+
+// MetaSave holds the mutable meta fields for a resource entry.
+type MetaSave struct {
+	Annotations fields.Annotations `json:"annotations,omitempty"`
+}

--- a/views/signal.go
+++ b/views/signal.go
@@ -28,7 +28,7 @@ type SignalInclude struct {
 
 // SignalSave describe the save view for a signal.
 type SignalSave struct {
-	resource.MetaSave
+	MetaSave
 	SignalSaveAttributes
 }
 


### PR DESCRIPTION
commit ea64337d0232ddc580866aadae167cc46f0eccb5 (HEAD -> fixes-1, origin/fixes-1)
Author: Sindre Myren <sindre@clarify.io>
Date:   Wed Jun 22 15:19:04 2022 +0200

    jsonrpc/resources: move MetaSave to views (breaking)
