### PR TITLE
jsonrpc/resource: remove FilterField method (breaking)

### DIFF
--- a/jsonrpc/resource/request_select.go
+++ b/jsonrpc/resource/request_select.go
@@ -61,15 +61,6 @@ func (req SelectRequest[R]) Filter(f query.FilterType) SelectRequest[R] {
 	return req
 }
 
-// FilterField returns a new request with the specified field filter added to
-// existing filters with logical AND.
-//
-// Deprecated: use Filter(query.Field(path, cmp)) instead.
-func (req SelectRequest[R]) FilterField(path string, cmp query.Comparison) SelectRequest[R] {
-	req.query.Filter = query.And(req.query.Filter, query.Field(path, cmp))
-	return req
-}
-
 // Limit returns a new request that limits the number of matches. Setting n < 0
 // will use the default limit.
 func (req SelectRequest[R]) Limit(n int) SelectRequest[R] {

--- a/resource_data_frame.go
+++ b/resource_data_frame.go
@@ -49,15 +49,6 @@ func (req DataFrameRequest) Filter(filter query.FilterType) DataFrameRequest {
 	return req
 }
 
-// FilterField returns a new request that includes Items matching the
-// provided filter.
-//
-// Deprecated: use Filter(query.Field(path, cmp)) instead.
-func (req DataFrameRequest) FilterField(path string, cmp query.Comparison) DataFrameRequest {
-	req.parent = req.parent.FilterField(path, cmp)
-	return req
-}
-
 // Limit returns a new request that limits the number of matches. Setting n < 0
 // will use the max limit.
 func (req DataFrameRequest) Limit(n int) DataFrameRequest {


### PR DESCRIPTION
commit 362827ba3fb360b272bc2fc6d2e68474533cc6de (HEAD -> fixes-2, origin/fixes-2)
Author: Sindre Myren <sindre@clarify.io>
Date:   Wed Jun 22 15:19:56 2022 +0200

    jsonrpc/resource: remove FilterField method (breaking)
