### PR TITLE
Introduce new package "automation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,32 @@ This SDK is following [Semantic Versioning][semver]. The SDK is currently in a v
 
 ## Features
 
-This SDK is currently written for [Clarify API v1.1beta2][docs-v1.1beta2], and include the following features:
+This SDK is currently written for [Clarify API v1.1beta2][docs-v1.1beta2], and include the following features, based on your integration access configuration:
+
+Always possible:
 
 - Compose Clarify data frames using the `data` sub-package.
-- Write signal meta-data to Clarify with `client.SaveSignals`. See [example](examples/save_signals/).
-- Write data frames to Clarify with `client.Insert`. See [example](examples/save_signals/).
+- Write signal meta-data to Clarify with `client.SaveSignals` (scoped to the current integration). See [examples/save_signals](examples/save_signals/).
+- Write data frames to Clarify with `client.Insert` (scoped to the current integration). See [examples/insert](examples/insert/).
+
+When access to the Admin namespace is granted in Clarify ` (scoped to entire organization):
+
+- Read signal meta-data to Clarify with `client.SelectSignals`. Allows side-loading related items. See [examples/select_signals](examples/select_signals/).
+- Publish signals as items directly with `client.PublishSignals`, or more conveniently via the `automation` package. See [examples/publish_signals](examples/publish_signals/) for the latter.
+
+When access to the Clarify namespace is granted in Clarify (scoped to entire organization):
+
+- Read item meta-data from Clarify via `client.SelectItems`. See [examples/select_items](examples/select_items/).
+- Read time-series data from Clarify via `client.DataFrame`. See [examples/data_frame](examples/select_items/).
 
 [clarify]: https://clarify.io/
 [semver]: https://semver.org/
 [docs]: https://docs.clarify.io
 [docs-v1.1beta2]: https://docs.clarify.io/1.1beta2
+
+## Setting up automation routines
+
+To quickly set-up your own automation routines, you can get started with our [automation template repository](https://github.com/clarify/template-clarify-automation). This template let's you customize and build your own automation binary and easily run it inside GitHub Actions; no external hosting environment is required (unless you want to).
 
 ## Copyright
 

--- a/automation/doc.go
+++ b/automation/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2022 Searis AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package automation offers tools aimed at building automated routines.
+package automation

--- a/automation/publish_signals.go
+++ b/automation/publish_signals.go
@@ -1,0 +1,263 @@
+// Copyright 2022 Searis AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package automation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"runtime/debug"
+
+	"github.com/clarify/clarify-go"
+	"github.com/clarify/clarify-go/query"
+	"github.com/clarify/clarify-go/views"
+	"golang.org/x/exp/maps"
+)
+
+const (
+	selectSignalsPageSize  = 1000
+	publishSignalsPageSize = 500
+)
+
+// Annotations used by automation tasks.
+const (
+	AnnotationPrefix                    = "clarify/clarify-go/"
+	AnnotationPublisherName             = AnnotationPrefix + "publisher/name"
+	AnnotationPublisherTransformVersion = AnnotationPrefix + "publisher/transform-version"
+	AnnotationPublisherSignalID         = AnnotationPrefix + "publisher/signal-id"
+	AnnotationPublisherSignalAttributes = AnnotationPrefix + "publisher/signal-attributes"
+)
+
+// LogOptions describe the options for operation logs.
+type LogOptions struct {
+	// Verbose, when true, enables detailed logs, such as full JSON summaries of
+	// operations.
+	Verbose bool
+
+	// Out describe the destination writer for logs. If unset, all logging is
+	// disabled.
+	Out io.Writer
+}
+
+func (opts LogOptions) EncodeJSON(v any) {
+	if opts.Out == nil {
+		return
+	}
+	enc := json.NewEncoder(opts.Out)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(v)
+}
+
+func (opts LogOptions) Printf(format string, a ...any) {
+	if opts.Out == nil {
+		return
+	}
+	fmt.Fprintf(opts.Out, format, a...)
+}
+
+// PublishOptions describe options that can be supplied when running a
+// PublishRuleSet.
+type PublishOptions struct {
+	LogOptions
+
+	// DryRun, if true, does not run the automation, but rather logs what it's
+	// planning to do.
+	DryRun bool
+
+	// Publisher is a name describing the publisher application. The default is
+	// the declared path of the main module.
+	Publisher string
+}
+
+func (opts PublishOptions) withDefaults() PublishOptions {
+	if opts.Publisher == "" {
+		info, ok := debug.ReadBuildInfo()
+		if ok {
+			opts.Publisher = info.Main.Path
+		}
+	}
+	return opts
+}
+
+// PublishSignals allows you to automate signal publishing from one or more
+// source integrations.
+type PublishSignals struct {
+	// Integrations must list the IDs of the integrations to publish signals
+	// from. If this list is empty, the rule set is a no-op.
+	Integrations []string
+
+	// SignalsFilter can optionally be specified to limit which signals to
+	// publish.
+	SignalsFilter query.FilterType
+
+	// TransformVersion should be changed if you want existing items to be
+	// republished despite the source signal being unchanged.
+	TransformVersion string
+
+	// Transforms is a list of transforms to apply when publishing the signals.
+	// The transforms are applied in order.
+	Transforms []func(item *views.ItemSave)
+}
+
+// Do performs the automation against c with the passed in opts.
+func (p PublishSignals) Do(ctx context.Context, c *clarify.Client, opts PublishOptions) error {
+	var total int
+	defer func() {
+		var suffix string
+		if opts.DryRun {
+			suffix = " (dry-run)"
+		}
+		opts.Printf("-- Published %d signals from %d integrations%s.\n", total, len(p.Integrations), suffix)
+	}()
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	opts = opts.withDefaults()
+
+	// We iterate signals without requesting the total count. This is an
+	// optimization bet that total % limit == 0 is uncommon.
+	q := query.Query{
+		Filter: p.SignalsFilter.Filter(),
+		Sort:   []string{"id"},
+		Limit:  selectSignalsPageSize,
+	}
+
+	items := make(map[string]views.ItemSave)
+	flush := func(integrationID string) error {
+		var suffix string
+		if opts.DryRun {
+			suffix = " (dry-run)"
+		}
+		opts.Printf("Publish %d items%s...\n", len(items), suffix)
+		if opts.Verbose {
+			opts.Printf("itemsBySignal:\n")
+			opts.EncodeJSON(items)
+		}
+		if !opts.DryRun {
+			result, err := c.PublishSignals(integrationID, items).Do(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to publish signals: %w", err)
+			}
+			if opts.Verbose {
+				opts.Printf("result:\n")
+				opts.EncodeJSON(result)
+			}
+		}
+
+		total += len(items)
+		maps.Clear(items)
+		return nil
+	}
+
+	for _, id := range p.Integrations {
+		q.Skip = 0
+		more := true
+		for more {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+
+			var err error
+			more, err = p.addItems(ctx, items, c, id, q, opts)
+			if err != nil {
+				return err
+			}
+			q.Skip += q.Limit
+
+			if len(items) >= publishSignalsPageSize {
+				if err := flush(id); err != nil {
+					return err
+				}
+			}
+		}
+
+		if err := flush(id); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// addItems adds items that require update to dest from all signals matching
+// the integration ID and query q.
+func (p PublishSignals) addItems(ctx context.Context, dest map[string]views.ItemSave, c *clarify.Client, integrationID string, q query.Query, opts PublishOptions) (bool, error) {
+	results, err := c.SelectSignals(integrationID).
+		Query(q).
+		Include("item").Do(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	// This logic only updates items if the signals has changed since last time
+	// the item was published, or if our transform version has changed.
+	prevItemsBySignal := make(map[string]views.Item, len(results.Included.Items))
+	for _, item := range results.Included.Items {
+		prevItemsBySignal[item.Meta.Annotations.Get(AnnotationPublisherSignalID)] = item
+	}
+
+	for _, signal := range results.Data {
+		// Only update item if either the source signal or transform version
+		// have changed.
+		prevItem, ok := prevItemsBySignal[signal.ID]
+		ok = ok && prevItem.Meta.Annotations.Get(AnnotationPublisherTransformVersion) == p.TransformVersion
+		ok = ok && prevItem.Meta.Annotations.Get(AnnotationPublisherSignalAttributes) == signal.Meta.AttributesHash.String()
+		if ok {
+			if opts.Verbose {
+				opts.Printf("Skip signal %s: item is up-to-date\n", signal.ID)
+			}
+			continue
+		}
+
+		item := views.PublishedItem(signal)
+		// Before running configured transforms, set the initial visible value
+		// to the value from the existing item, or true for new items.
+		if prevItem.ID != "" {
+			item.Visible = prevItem.Attributes.Visible
+		} else {
+			item.Visible = true
+		}
+
+		for _, f := range p.Transforms {
+			f(&item)
+		}
+
+		// After running configured transformations, set automation package
+		// annotations.
+		item.Annotations.Set(AnnotationPublisherName, opts.Publisher)
+		item.Annotations.Set(AnnotationPublisherTransformVersion, p.TransformVersion)
+		item.Annotations.Set(AnnotationPublisherSignalAttributes, signal.Meta.AttributesHash.String())
+		item.Annotations.Set(AnnotationPublisherSignalID, signal.ID)
+
+		dest[signal.ID] = item
+	}
+
+	var more bool
+	if results.Meta.Total >= 0 {
+		// More can be calculated exactly when the total count was requested (or
+		// calculated for free by the backend).
+		more = q.Skip+len(results.Data) < results.Meta.Total
+	} else {
+		// Fallback to approximate the more value when total was not explicitly
+		// requested. For large values of q.Limit, this approximation is likely
+		// faster -- on average -- then to request a total count.
+		more = (len(results.Data) == q.Limit)
+	}
+	return more, nil
+
+}

--- a/examples/publish_signals/main.go
+++ b/examples/publish_signals/main.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"log"
 	"os"
 	"strings"
 
 	clarify "github.com/clarify/clarify-go"
+	"github.com/clarify/clarify-go/automation"
 	"github.com/clarify/clarify-go/query"
 	"github.com/clarify/clarify-go/views"
 	"golang.org/x/text/cases"
@@ -46,70 +46,28 @@ func main() {
 	ctx := context.Background()
 	client := creds.Client(ctx)
 
-	// For this example, the signals we want to publish are created by the same
-	// integration that we are using to select them. Note that this isn't a
-	// requirement; for production cases, you may want this integration ID to be
-	// configured to be something else.
-	integrationID := creds.Integration
-
-	selectResult, err := client.SelectSignals(integrationID).Filter(query.Comparisons{
-		"annotations." + keyExampleName:    query.Equal(exampleName),
-		"annotations." + keyExamplePublish: query.Equal(annotationTrue),
-	}).Include("item").Limit(100).Do(ctx)
-	if err != nil {
-		panic(err)
-	}
-
-	// This logic only updates items if the signals has changed since last time
-	// the item was published, or if our transform version has changed.
-	prevItemsBySignal := make(map[string]views.Item, len(selectResult.Included.Items))
-	for _, item := range selectResult.Included.Items {
-		prevItemsBySignal[item.Meta.Annotations.Get(keySignalID)] = item
-	}
-
-	newItems := make(map[string]views.ItemSave, len(selectResult.Data))
-
-	for _, signal := range selectResult.Data {
-		// Only update item if the source signal has changed.
-		prevItem, ok := prevItemsBySignal[signal.ID]
-		ok = ok && prevItem.Meta.Annotations.Get(keyTransformVersion) == transformVersion
-		ok = ok && prevItem.Meta.Annotations.Get(keySignalAttributesHash) == signal.Meta.AttributesHash.String()
-		if ok {
-			log.Printf("Skip signal %s: item is up-to-date", signal.ID)
-			continue
-		}
-
-		// Use visible status from previous item.
-		visible := prevItem.Attributes.Visible
-		if prevItem.ID == "" {
-			visible = true
-		}
-
-		newItems[signal.ID] = views.PublishedItem(signal,
+	rule := automation.PublishSignals{
+		// For this example, the signals we want to publish are created by the same
+		// integration that we are using to select them. Note that this isn't a
+		// requirement; for production cases, you may want this integration ID to be
+		// configured to be something else.
+		Integrations: []string{creds.Integration},
+		SignalsFilter: query.Comparisons{
+			"annotations." + keyExampleName:    query.Equal(exampleName),
+			"annotations." + keyExamplePublish: query.Equal(annotationTrue),
+		}.Filter(),
+		TransformVersion: transformVersion,
+		Transforms: []func(item *views.ItemSave){
 			transformEnumValuesToFireEmoji,
 			transformLabelValuesToTitle,
-			func(item *views.ItemSave) {
-				item.Annotations.Set(keyExampleName, "publish_signals")
-				item.Annotations.Set(keyTransformVersion, transformVersion)
-				item.Annotations.Set(keySignalAttributesHash, signal.Meta.AttributesHash.String())
-				item.Annotations.Set(keySignalID, signal.ID)
-				item.Visible = visible
-			},
-		)
+		},
 	}
-
-	if len(newItems) == 0 {
-		log.Printf("All items up-to-date")
-		return
+	if err := rule.Do(ctx, client, automation.PublishOptions{LogOptions: automation.LogOptions{
+		Verbose: true,
+		Out:     os.Stderr,
+	}}); err != nil {
+		log.Fatalf("fatal: %v", err)
 	}
-	log.Printf("Updating %d/%d items", len(newItems), len(selectResult.Data))
-	result, err := client.PublishSignals(integrationID, newItems).Do(ctx)
-	if err != nil {
-		panic(err)
-	}
-	enc := json.NewEncoder(os.Stdout)
-	enc.SetIndent("", "  ")
-	enc.Encode(result)
 }
 
 // transformEnumValuesToFireEmoji is an example transform that replaces the enum
@@ -125,8 +83,8 @@ func transformEnumValuesToFireEmoji(item *views.ItemSave) {
 	}
 }
 
-// transformLabelValuesToTitle transforms label values from format "multiple words"
-// to "Multiple Words".
+// transformLabelValuesToTitle transforms label values from format "multiple
+// words" to "Multiple Words".
 func transformLabelValuesToTitle(item *views.ItemSave) {
 	for k, labels := range item.Labels {
 		for i, label := range labels {


### PR DESCRIPTION
Used by https://github.com/clarify/template-clarify-automation (repo is private for now, but will be made public when PR is merged).

---

commit 3c085eddafe23952dc1e7fd48b37a3976bb1d691 (HEAD -> automation, origin/automation)
Author: Sindre Myren <sindre@clarify.io>
Date:   Wed Oct 12 14:28:23 2022 +0200

    .github/workflows/go.yml: update actions

commit d8bf0b6015fa30f7aad587ceac643b86048c1f0b
Author: Sindre Myren <sindre@clarify.io>
Date:   Wed Oct 5 13:01:20 2022 +0200

    README: update features list and link to template repo

commit 201d6f3dfd89558f5f5a683f62a6b4f84d93ed7b
Author: Sindre Myren <sindre@clarify.io>
Date:   Wed Oct 5 11:43:09 2022 +0200

    examples/publish_signals: update to use automation

    Update example to use new automation package. This greatly reduce the
    code-size for the publish signals example.

commit efd53551851b80198caa5931eb72c7608e73b5f4
Author: Sindre Myren <sindre@clarify.io>
Date:   Sun Sep 25 22:45:04 2022 +0200

    automation: new package, add PublishSignals type

    The new automation package is an utility package to allow setting up
    automations on top of Clarify.

    As a first automation type, we are adding a PublishSignals automation,
    which allow more easily publishing signals as items through a defined
    set of rules.
