### PR TITLE
BAC-296: update `Client.Evaluate` call to version 1.2alpha1 (breaking)

### DIFF
--- a/automation/routine_evaluate_actions.go
+++ b/automation/routine_evaluate_actions.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Searis AS
+// Copyright 2023-2024 Searis AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import (
 // well as annotations for passing on to actions.
 type Evaluation struct {
 	// Items lists item aggregations for items with known IDs.
-	Items []fields.ItemAggregation
+	Items []fields.EvaluateItem
 
 	// Calculations lists calculations to perform. A calculation can reference
 	// items or previous calculations.
@@ -75,7 +75,9 @@ func (e EvaluateActions) Do(ctx context.Context, cfg *Config) error {
 	}
 
 	selection, err := client.Clarify().
-		Evaluate(e.Evaluation.Items, e.Evaluation.Calculations, dataQuery).
+		Evaluate(dataQuery).
+		Items(e.Evaluation.Items...).
+		Calculations(e.Evaluation.Calculations...).
 		Do(ctx)
 	if err != nil {
 		return err

--- a/examples/automation_cli/routines.go
+++ b/examples/automation_cli/routines.go
@@ -181,8 +181,8 @@ func transformLabelValuesToTitle(item *views.ItemSave) {
 
 var detectFire = automation.EvaluateActions{
 	Evaluation: automation.Evaluation{
-		Items: []fields.ItemAggregation{
-			{Alias: "fire_rate", ID: os.Getenv("CLARIFY_EXAMPLE_STATUS_ITEM_ID"), Aggregation: fields.AggregateStateHistRate, State: 1},
+		Items: []fields.EvaluateItem{
+			{Alias: "fire_rate", ID: os.Getenv("CLARIFY_EXAMPLE_STATUS_ITEM_ID"), TimeAggregation: fields.TimeAggregationRate, State: 1},
 		},
 		Calculations: []fields.Calculation{
 			{Alias: "has_fire", Formula: "fire_rate > 0"}, // return 1.0 when true.

--- a/examples/devdata_cli/commands.go
+++ b/examples/devdata_cli/commands.go
@@ -722,7 +722,7 @@ func (p *program) evaluateCommand() *ffcli.Command {
 }
 
 func (p *program) evaluate(ctx context.Context, config evaluateConfig) error {
-	var items []fields.ItemAggregation
+	var items []fields.EvaluateItem
 	if err := json.Unmarshal([]byte(config.items), &items); err != nil {
 		return fmt.Errorf("-items: %w", err)
 	}
@@ -746,7 +746,9 @@ func (p *program) evaluate(ctx context.Context, config evaluateConfig) error {
 		data = data.Last(config.last)
 	}
 
-	req := p.client.Clarify().Evaluate(items, calculations, data)
+	req := p.client.Clarify().Evaluate(data).
+		Items(items...).
+		Calculations(calculations...)
 	if config.includeItems {
 		req = req.Include("items")
 	}

--- a/examples/evaluate/main.go
+++ b/examples/evaluate/main.go
@@ -40,8 +40,8 @@ func main() {
 	if len(selection.Data) == 0 {
 		panic("this example require your organization to expose at least one item")
 	}
-	items := []fields.ItemAggregation{
-		{Alias: "i1", ID: selection.Data[0].ID, Aggregation: fields.AggregateAvg},
+	items := []fields.EvaluateItem{
+		{Alias: "i1", ID: selection.Data[0].ID, TimeAggregation: fields.TimeAggregationAvg},
 	}
 	calculations := []fields.Calculation{
 		{Alias: "c1", Formula: "sin(a)"},
@@ -49,7 +49,10 @@ func main() {
 		{Alias: "c3", Formula: "max(c1,c2)"},
 	}
 
-	result, err := client.Clarify().Evaluate(items, calculations, data).Do(ctx)
+	result, err := client.Clarify().Evaluate(data).
+		Items(items...).
+		Calculations(calculations...).
+		Do(ctx)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/request/method_relational.go
+++ b/internal/request/method_relational.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Searis AS
+// Copyright 2023-2024 Searis AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -62,5 +62,11 @@ func (req Relational[R]) Include(relationships ...string) Relational[R] {
 
 // Do performs the request against the server and returns the result.
 func (req Relational[R]) Do(ctx context.Context) (*R, error) {
-	return req.parent.do(ctx, includeParam.Value(req.include))
+	return req.do(ctx, includeParam.Value(req.include))
+}
+
+func (req Relational[R]) do(ctx context.Context, params ...jsonrpc.Param) (*R, error) {
+	arr := append(params, includeParam.Value(req.include))
+
+	return req.parent.do(ctx, arr...)
 }


### PR DESCRIPTION
i have updated the clarify go sdk to support the new `evaluate` parameter `groups`. i have also updated some names to match the changes introduced in BAC-282. lastly i have updated the `automation` and `examples` packages to use the new builder style `EvaluateRequest` type