### PR TITLE
Fix condition in binary search result handling

### DIFF
--- a/fields/maps.go
+++ b/fields/maps.go
@@ -134,8 +134,8 @@ func (l *Labels) Remove(key string, value string) {
 		delete((*l), key)
 		return
 	}
-	slices.Sort((*l)[key])
-	if i, found := slices.BinarySearch(ll, value); !found {
+	slices.Sort(ll)
+	if i, found := slices.BinarySearch(ll, value); found {
 		ll = slices.Delete(ll, i, i+1)
 	}
 	if len(ll) == 0 {


### PR DESCRIPTION
The logic around `found` and when to delete a value was inverted.